### PR TITLE
Ska api fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 __pycache__
+/build/
+/.eggs
+/record.txt
+/*.egg-info

--- a/kadi_apps/app.py
+++ b/kadi_apps/app.py
@@ -4,6 +4,7 @@
 """
 
 import logging
+import argparse
 
 from pathlib import Path
 
@@ -46,6 +47,17 @@ def get_app(name=__name__, settings='devel'):
     return app
 
 
-if __name__ == "__main__":
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--unit-test', action='store_const', const='unit_test', dest='settings', default='devel')
+    return parser
+
+
+def main():
     # this starts the development server
-    get_app(settings='devel').run(host='0.0.0.0')
+    args = get_parser().parse_args()
+    get_app(settings=args.settings).run(host='0.0.0.0')
+
+
+if __name__ == "__main__":
+    main()

--- a/kadi_apps/blueprints/ska_api/api.py
+++ b/kadi_apps/blueprints/ska_api/api.py
@@ -7,8 +7,9 @@ import json
 
 APPS = {
     ('mica', 'starcheck'): ['get_*'],
+    ('mica', 'archive', 'aca_dark', 'dark_cal'): ['get_dark_cal_id', 'get_dark_cal_image'],
     ('kadi', 'events'): ['*.filter'],
-    ('kadi', 'commands'): ['get_cmds'],
+    ('kadi', 'commands'): ['get_cmds', 'get_observations', 'get_starcats'],
     ('kadi', 'commands', 'states'): ['get_states']}
 
 

--- a/kadi_apps/blueprints/ska_api/api.py
+++ b/kadi_apps/blueprints/ska_api/api.py
@@ -6,13 +6,15 @@ import json
 
 
 APPS = {
+    ('agasc',): ['get_star', 'get_stars', 'get_agasc_cone'],
     ('mica', 'starcheck'): ['get_*'],
     ('mica', 'archive', 'aca_dark', 'dark_cal'): [
         'get_dark_cal_id', 'get_dark_cal_image', 'get_dark_cal_props'
     ],
     ('kadi', 'events'): ['*.filter'],
     ('kadi', 'commands'): ['get_cmds', 'get_observations', 'get_starcats'],
-    ('kadi', 'commands', 'states'): ['get_states']}
+    ('kadi', 'commands', 'states'): ['get_states']
+}
 
 
 blueprint = Blueprint('ska_api', __name__, template_folder='templates')

--- a/kadi_apps/blueprints/ska_api/api.py
+++ b/kadi_apps/blueprints/ska_api/api.py
@@ -9,7 +9,7 @@ APPS = {
     ('agasc',): ['get_star', 'get_stars', 'get_agasc_cone'],
     ('mica', 'starcheck'): ['get_*'],
     ('mica', 'archive', 'aca_dark', 'dark_cal'): [
-        'get_dark_cal_id', 'get_dark_cal_image', 'get_dark_cal_props'
+        'get_dark_cal_id', 'get_dark_cal_ids', 'get_dark_cal_image', 'get_dark_cal_props'
     ],
     ('kadi', 'events'): ['*.filter'],
     ('kadi', 'commands'): ['get_cmds', 'get_observations', 'get_starcats'],

--- a/kadi_apps/blueprints/ska_api/api.py
+++ b/kadi_apps/blueprints/ska_api/api.py
@@ -7,7 +7,9 @@ import json
 
 APPS = {
     ('mica', 'starcheck'): ['get_*'],
-    ('mica', 'archive', 'aca_dark', 'dark_cal'): ['get_dark_cal_id', 'get_dark_cal_image'],
+    ('mica', 'archive', 'aca_dark', 'dark_cal'): [
+        'get_dark_cal_id', 'get_dark_cal_image', 'get_dark_cal_props'
+    ],
     ('kadi', 'events'): ['*.filter'],
     ('kadi', 'commands'): ['get_cmds', 'get_observations', 'get_starcats'],
     ('kadi', 'commands', 'states'): ['get_states']}

--- a/kadi_apps/blueprints/ska_api/templates/help.html
+++ b/kadi_apps/blueprints/ska_api/templates/help.html
@@ -375,7 +375,7 @@ ul.auto-toc {
 <h1>API URL syntax</h1>
 <p>The general URL syntax for querying data via the API interface is as follows:</p>
 <pre class="literal-block">
-http://web-kadi-test.cfa.harvard.edu/api/&lt;package&gt;/&lt;module&gt;/&lt;function&gt;?&lt;arg1&gt;=&lt;val1&gt;&amp;&lt;arg2&gt;=val2...
+  {{ url_for('ska_api.api', path='asdasdasd', _external=True) }}/&lt;package&gt;/&lt;module&gt;/&lt;function&gt;?&lt;arg1&gt;=&lt;val1&gt;&amp;&lt;arg2&gt;=val2...
 </pre>
 <p>This roughly equivalent to the Python pseudo-code:</p>
 <pre class="literal-block">
@@ -383,7 +383,7 @@ from &lt;package&gt;.&lt;module&gt; import &lt;function&gt;
 &lt;function&gt;(arg1=val1, arg2=val2)
 </pre>
 <p>For example:</p>
-<p><a class="reference external" href="http://web-kadi-test.cfa.harvard.edu/api/kadi/events/manvrs/filter?start=2019:001&amp;stop=2019:002">http://web-kadi-test.cfa.harvard.edu/api/kadi/events/manvrs/filter?start=2019:001&amp;stop=2019:002</a></p>
+<p><a class="reference external" href="{{ url_for('ska_api.api', path='kadi/events/manvrs/filter') }}?start=2019:001&amp;stop=2019:002">{{ url_for('ska_api.api', path='kadi/events/manvrs/filter', _external=True) }}?start=2019:001&amp;stop=2019:002</a></p>
 <p>This is equivalent to the Python code:</p>
 <pre class="literal-block">
 from kadi.events import manvrs
@@ -404,14 +404,14 @@ manvrs.filter(start='2019:001', stop='2019:002')
 either a list of dicts (<tt class="docutils literal">rows</tt>) or a dict of lists (<tt class="docutils literal">columns</tt>).  For large query results the
 <tt class="docutils literal">columns</tt> option will generally be more compact because the table column names are not repeated for
 every row. For example:</p>
-<p><a class="reference external" href="http://web-kadi-test.cfa.harvard.edu/api/kadi/events/manvrs/filter?start=2019:001&amp;stop=2019:002&amp;table_format=columns">http://web-kadi-test.cfa.harvard.edu/api/kadi/events/manvrs/filter?start=2019:001&amp;stop=2019:002&amp;table_format=columns</a></p>
+<p><a class="reference external" href="{{ url_for('ska_api.api', path='kadi/events/manvrs/filter') }}?start=2019:001&amp;stop=2019:002&amp;table_format=columns">{{ url_for('ska_api.api', path='kadi/events/manvrs/filter', _external=True) }}?start=2019:001&amp;stop=2019:002&amp;table_format=columns</a></p>
 </div>
 <div class="section" id="timing">
 <h2>Timing</h2>
 <p>A second special option is <tt class="docutils literal">report_timing</tt>, which returns timing information on the query
 instead of the query data.  This may be useful for characterizing the performance of the
 web service (which is not very speedy).  Example:</p>
-<p><a class="reference external" href="http://web-kadi-test.cfa.harvard.edu/api/kadi/events/manvrs/filter?start=2019:001&amp;stop=2019:002&amp;report_timing=1">http://web-kadi-test.cfa.harvard.edu/api/kadi/events/manvrs/filter?start=2019:001&amp;stop=2019:002&amp;report_timing=1</a></p>
+<p><a class="reference external" href="{{ url_for('ska_api.api', path='kadi/events/manvrs/filter') }}?start=2019:001&amp;stop=2019:002&amp;report_timing=1">{{ url_for('ska_api.api', path='kadi/events/manvrs/filter', _external=True) }}?start=2019:001&amp;stop=2019:002&amp;report_timing=1</a></p>
 </div>
 </div>
 <div class="section" id="available-apis">

--- a/kadi_apps/tests/conftest.py
+++ b/kadi_apps/tests/conftest.py
@@ -10,16 +10,25 @@ def _run_app():
 
 @pytest.fixture(scope="session")
 def test_server(request):
-    print('kadi_apps.tests.conftest Starting Flask App')
+    import requests
     from multiprocessing import Process
-    p = Process(target=_run_app)
-    p.start()
-    time.sleep(2)  # this is to let the server spin up
     info = {
         'url': 'http://127.0.0.1:5000',
         'user': 'test_user',
         'password': 'test_password',
     }
+    print('kadi_apps.tests.conftest Starting Flask App')
+    p = Process(target=_run_app)
+    p.start()
+    r = None
+    for i in range(20):
+        try:
+            r = requests.get(info['url'])
+            break  # if there is any response we call it a success
+        except Exception:
+            time.sleep(0.2)
+    if r is None:
+        print(f'Test server failed to start: {r}')
     yield info
     print('kadi_apps.tests.conftest Killing Flask App')
     p.kill()

--- a/kadi_apps/tests/test_ska_api.py
+++ b/kadi_apps/tests/test_ska_api.py
@@ -1,0 +1,174 @@
+import numpy as np
+import requests
+import re
+from astropy.table import Table
+
+from kadi.commands import get_starcats
+from kadi.commands import get_observations
+
+
+def test_starcheck_att(test_server):
+    from mica.starcheck import get_att
+    obsid = 8008
+    api_url = f"{test_server['url']}/ska_api"
+    path = 'mica/starcheck/get_att'
+    response = requests.get(f"{api_url}/{path}?{obsid=}")
+    att = get_att(obsid=obsid)
+    assert att == response.json()
+
+
+def test_starcheck_dither(test_server):
+    from mica.starcheck import get_dither
+    obsid = 8008
+    api_url = f"{test_server['url']}/ska_api"
+    path = 'mica/starcheck/get_dither'
+    response = requests.get(f"{api_url}/{path}?{obsid=}")
+    dither = get_dither(obsid=obsid)
+    assert dither == response.json()
+
+
+def test_starcheck_starcat(test_server):
+    from mica.starcheck import get_starcat
+    obsid = 8008
+    api_url = f"{test_server['url']}/ska_api"
+    path = 'mica/starcheck/get_starcat'
+    response = requests.get(f"{api_url}/{path}?{obsid=}")
+    starcat = get_starcat(obsid=obsid)
+    starcat_api = Table(response.json())
+    assert np.all(starcat == starcat_api)
+
+
+def test_starcheck_catalog(test_server):
+    from mica.starcheck import get_starcheck_catalog, get_starcheck_catalog_at_date
+
+    obsid = 8008
+    api_url = f"{test_server['url']}/ska_api"
+    path = 'mica/starcheck/get_starcheck_catalog'
+    response = requests.get(f"{api_url}/{path}?{obsid=}")
+    catalog = get_starcheck_catalog(obsid=obsid)
+    catalog_api = response.json()
+    catalog_api['manvr'] = Table(catalog_api['manvr'])
+    catalog_api['cat'] = Table(catalog_api['cat'])
+    keys = list(catalog.keys())
+    for key in keys:
+        assert np.all(catalog[key] == catalog_api[key])
+
+    date = '2007:002:04:31:43.965'
+    path = 'mica/starcheck/get_starcheck_catalog_at_date'
+    response = requests.get(f"{api_url}/{path}?{date=}")
+    catalog = get_starcheck_catalog_at_date(date=date)
+    catalog_api = response.json()
+    catalog_api['manvr'] = Table(catalog_api['manvr'])
+    catalog_api['cat'] = Table(catalog_api['cat'])
+    keys = list(catalog.keys())
+    for key in keys:
+        assert np.all(catalog[key] == catalog_api[key])
+
+
+def test_starcheck_monitor_windows(test_server):
+    from mica.starcheck import get_monitor_windows
+
+    api_url = f"{test_server['url']}/ska_api"
+
+    start, stop = '2010:010', '2010:020'
+    path = 'mica/starcheck/get_monitor_windows'
+
+    windows = get_monitor_windows(start, stop)
+    response = requests.get(f"{api_url}/{path}?{start=}&{stop=}")
+    windows_api = response.json()
+    windows_api[0]['catalog']['warnings'] = Table(windows_api[0]['catalog']['warnings'])
+    windows_api[0]['catalog']['cat'] = Table(windows_api[0]['catalog']['cat'])
+    windows_api[0]['catalog']['manvr'] = Table(windows_api[0]['catalog']['manvr'])
+    windows_api = Table(windows_api)
+    keys = list(windows.keys())
+    keys.remove('catalog')
+
+    assert np.all(windows[keys] == windows_api[keys])
+
+
+def test_dark_cal_image(test_server):
+    from mica.archive.aca_dark import dark_cal
+
+    date = '2022:001'
+    api_url = f"{test_server['url']}/ska_api"
+    path = 'mica/archive/aca_dark/dark_cal/get_dark_cal_id'
+    url = f"{api_url}/{path}?date='{date}'"
+    r = requests.get(url)
+    dark_cal_id = dark_cal.get_dark_cal_id(date=date)
+    assert dark_cal_id == r.json()
+
+
+def test_dark_cal_props(test_server):
+    from mica.archive.aca_dark import dark_cal
+
+    date = '2022:001'
+    api_url = f"{test_server['url']}/ska_api"
+    path = 'mica/archive/aca_dark/dark_cal/get_dark_cal_id'
+    url = f"{api_url}/{path}?date='{date}'"
+    r = requests.get(url)
+    dark_cal_id = dark_cal.get_dark_cal_id(date=date)
+    assert dark_cal_id == r.json()
+
+
+def test_dark_cal_id(test_server):
+    from mica.archive.aca_dark import dark_cal
+
+    date = '2022:001'
+    api_url = f"{test_server['url']}/ska_api"
+    path = 'mica/archive/aca_dark/dark_cal/get_dark_cal_id'
+    url = f"{api_url}/{path}?date='{date}'"
+    r = requests.get(url)
+    dark_cal_id = dark_cal.get_dark_cal_id(date=date)
+    assert dark_cal_id == r.json()
+
+
+def test_starcats(test_server):
+    api_url = f"{test_server['url']}/ska_api"
+    start = '2022:001'
+    stop = '2022:002'
+    obsid = None
+    starcats = get_starcats(start=start, stop=stop, obsid=obsid, scenario='flight')
+    url = f'{api_url}/kadi/commands/get_starcats?{start=}&{stop=}&scenario=flight'
+    r = requests.get(url)
+    starcats_api = [Table(cat) for cat in r.json()]
+    colnames = [
+        'slot', 'idx', 'id', 'type', 'sz', 'mag', 'maxmag', 'yang', 'zang', 'dim', 'res', 'halfw'
+    ]
+    for i in range(len(starcats)):
+        for col in colnames:
+            assert np.all(starcats[i][col] == starcats_api[i][col])
+        assert np.all(starcats[i] == starcats_api[i])
+
+
+def test_observations(test_server):
+    api_url = f"{test_server['url']}/ska_api"
+    starcat_date = '2022:001:17:00:58.521'
+    observation = get_observations(starcat_date=starcat_date, scenario='flight')[0]
+    url = f'{api_url}/kadi/commands/get_observations?{starcat_date=}&scenario=flight'
+    r = requests.get(url)
+    assert r.ok
+    observation_api = r.json()[0]
+    for key in observation_api:
+        if isinstance(observation_api[key], list):
+            observation_api[key] = tuple(observation_api[key])
+    assert observation_api == observation
+
+
+def test_errors(test_server):
+    api_url = f"{test_server['url']}/ska_api"
+
+    # this function is not allowed
+    url = f"{api_url}/mica/archive/aca_dark/dark_cal/get_dark_cal_dirs"
+    r = requests.get(url)
+    assert not r.ok
+    assert r.reason == 'NOT FOUND'
+    assert 'error' in r.json()
+    assert re.match('function get_dark_cal_dirs was not found or is not allowed', r.json()['error'])
+
+    # this module does not exist
+    url = f"{api_url}/mica/archive/aca_dark/dark_cal2/get_dark_cal_id"
+    r = requests.get(url)
+    assert not r.ok
+    assert r.reason == 'NOT FOUND'
+    assert 'error' in r.json()
+    assert re.match('no app module found for URL path', r.json()['error'])


### PR DESCRIPTION
## Description

This makes the following changes to the ska_api blueprint:
- return error codes when there is an error
- add a few more functions I want to use to the API:
  - agasc: `get_star`, `get_stars`, `get_agasc_cone`
  - mica.archive.aca_dark.dark_cal: `get_dark_cal_ids`, `get_dark_cal_id`, `get_dark_cal_image`, `get_dark_cal_props`
  - kadi.commands: `get_observations`, `get_starcats`
- numpy arrays output from ska_api functions are now encoded
- added ska_api unit tests

## Interface impacts

- Adds nine functions to the web API
- The API can now return 500 error if the output cannot be encoded, unless the argument `strict_encoding=false` is passed

## Testing

For testing, this requires sot/kadi/pull/241 and sot/mica/pull/273.

Astromon tests fail, but this is independent of this PR. For astromon tests to pass one needs sot/astromon/pull/26 and some test data.

### Unit tests

- [x] On OS-X

### Functional tests

