### PR TITLE
find_attitude: Report tolerance and fix error message

### DIFF
--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -67,7 +67,7 @@ def find_solutions_and_get_context():
     # No solutions, bummer.
     if not solutions:
         context['error_message'] = ('No matching solutions found.\n'
-                                    'Try increasing distance and/or magnitude tolerance.')
+                                    'Try increasing distance tolerance.')
         return context
 
     context['solutions'] = []

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -60,7 +60,11 @@ class="with-background"
 {% if solutions %}
   {% for solution in solutions %}
   <h2> Attitude solution </h2>
+
+  <p> Distance tolerance: {{ distance_tolerance }} arcsec. </p>
+
   <h4> Coordinates </h4>
+
   <div class="row">
     <div class="large-3 columns">
       <p> <strong>


### PR DESCRIPTION
## Description

During FSDS review, PCAD requested that the actually-used distance tolerance in find_attitude is reported.

This PR adds the distance tolerance to the results section. It also fixes a misleading error message.

## Interface impacts
None

## Testing 

### Unit tests
- [x] No unit tests

### Functional tests
This change is online in kadi-test.

This shows the reported tolerance:
![tolerance](https://user-images.githubusercontent.com/140523/182649383-6cef81be-ddd0-49f3-9bfd-cc7e79d84a94.jpg)

and this shows the corrected error message:
![error_msg](https://user-images.githubusercontent.com/140523/182649420-a8f9124a-0502-4c22-ac4a-5dce5bf5a39b.jpg)

