### PR TITLE
Optionally use MAUDE to get star data for find_attitude

### DIFF
--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from io import StringIO
 import os
 
 from flask import Blueprint, request
@@ -19,6 +20,41 @@ blueprint = Blueprint(
     __name__,
     template_folder='templates',
 )
+
+
+def get_stars_from_maude(date=None):
+    from maude import get_msids
+    import astropy.units as u
+    from cxotime import CxoTime
+    from astropy.table import Table
+    import numpy as np
+
+    msids = []
+    msids.extend([f"aoacyan{ii}" for ii in range(8)])
+    msids.extend([f"aoaczan{ii}" for ii in range(8)])
+    msids.extend([f"aoacmag{ii}" for ii in range(8)])
+    if date is not None:
+        start = CxoTime(date)
+        stop = start + 10 * u.s
+        kwargs = {'start': start, 'stop': stop}
+    else:
+        kwargs = {}
+    dat = get_msids(msids, **kwargs)
+    results = dat["data"]
+    out = {}
+    for result in results:
+        msid = result["msid"]
+        value = result["values"][-1]
+        out[msid] = value
+    tbl = Table()
+
+    tbl['slot'] = np.arange(8)
+    tbl['YAG'] = [out[f"AOACYAN{ii}"] for ii in range(8)]
+    tbl['ZAG'] = [out[f"AOACZAN{ii}"] for ii in range(8)]
+    tbl['MAG_ACA'] = [out[f"AOACMAG{ii}"] for ii in range(8)]
+    tbl.meta['date_solution'] = CxoTime(date).date
+
+    return tbl
 
 
 @blueprint.route("/", methods=['GET', 'POST'])
@@ -44,16 +80,34 @@ def index():
 
 def find_solutions_and_get_context():
     stars_text = request.form.get('stars_text', '')
-    context = {'stars_text': stars_text}
+    context = {}
+    if stars_text.strip() == '':
+        # Get date for solution, defaulting to NOW for any blank input
+        date_solution = request.form.get('date_solution', '').strip() or None
+        stars = get_stars_from_maude(date_solution)
 
-    # First parse the star text input
-    try:
-        stars = get_stars_from_text(stars_text)
-    except Exception as err:
-        context['error_message'] = ("{}\n"
-                                    "Does it look like one of the examples?"
-                                    .format(err))
-        return context
+        # Get a formatted version of the stars table that is used for finding
+        # the solutions. This gets put back into the web page output.
+        out = StringIO()
+        stars_context = stars.copy()
+        cols_new = ['yag', 'zag', 'mag']
+        stars_context.rename_columns(['YAG', 'ZAG', 'MAG_ACA'], cols_new)
+        for name in cols_new:
+            stars_context[name].format = '.2f'
+        stars_context.write(out, format='ascii.fixed_width', delimiter=' ')
+        context['stars_text'] = out.getvalue()
+        context['date_solution'] = stars.meta['date_solution']
+    else:
+        context['stars_text'] = stars_text
+
+        # First parse the star text input
+        try:
+            stars = get_stars_from_text(stars_text)
+        except Exception as err:
+            context['error_message'] = ("{}\n"
+                                        "Does it look like one of the examples?"
+                                        .format(err))
+            return context
 
     # Try to find solutions
     tolerance = float(request.form.get('distance_tolerance', '2.5'))
@@ -72,7 +126,11 @@ def find_solutions_and_get_context():
 
     context['solutions'] = []
     for solution in solutions:
-        summary_lines = solution['summary'].pformat(max_width=-1, max_lines=-1)
+        tbl = solution['summary']
+        tbl['YAG'].format = '.2f'
+        tbl['ZAG'].format = '.2f'
+        tbl['MAG_ACA'].format = '.2f'
+        summary_lines = tbl.pformat(max_width=-1, max_lines=-1)
         sol = {'att_fit': solution['att_fit'],
                'summary': os.linesep.join(summary_lines)}
         context['solutions'].append(sol)

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -52,7 +52,7 @@ def get_stars_from_maude(date=None):
     tbl['YAG'] = [out[f"AOACYAN{ii}"] for ii in range(8)]
     tbl['ZAG'] = [out[f"AOACZAN{ii}"] for ii in range(8)]
     tbl['MAG_ACA'] = [out[f"AOACMAG{ii}"] for ii in range(8)]
-    tbl.meta['date_solution'] = CxoTime(date).date
+    tbl.meta['date_solution'] = CxoTime(results[0]['times'][-1]).date
 
     return tbl
 

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -15,12 +15,22 @@ class="with-background"
 </form>
 
 <div class="row">
-  <div class="large-12 columns">
-    <p>Enter ACA star data below using either GRETA display A_ACA_ALL or as a simple text
-      table.<br>
-      Click Submit and wait for up to a minute for the attitude solution results.
-    </p>
-  </div>
+    <div class="large-12 columns">
+        <p>Choose one of the following options:
+        <ul>
+            <li> Enter ACA star data below using either GRETA display A_ACA_ALL
+                or as a simple text table.</li>
+            <li> Leave the Star data field blank and use MAUDE to fetch ACA star data.</li>
+            <ul>
+                <li> Enter a date to get the solution at a particular time. </li>
+                <li> Leave the date blank to get the solution at the current time.</li>
+            </ul>
+        </ul>
+        <br>
+        Click Submit and wait for up to a minute for the attitude solution
+        results.
+        </p>
+    </div>
 </div>
 
 <form action="/find_attitude/" method="post">
@@ -34,6 +44,15 @@ class="with-background"
   &nbsp;
   <div class="row">
     <div class="col">
+      <label for="date_solution">Solution date (if no Star data are supplied) </label>
+      <input type="text" class="form-control" id="date_solution" name="date_solution" value="{{date_solution}}">
+    </div>
+  </div>
+  &nbsp;
+  <div class="row">
+    <div class="col">
+     <label for="stars_text">Star data (leave blank to get star data from MAUDE) </label>
+
       <textarea
       class="form-control"
       style="font-family:Consolas,Monaco,Lucida Console,Liberation


### PR DESCRIPTION
## Description

Optionally use MAUDE to get star data for find_attitude.

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/348089/185763947-cb936fc4-1cb9-4378-8f74-384d7ec57f6e.png">

Closes #16


<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Closes https://github.com/sot/ska-projects/issues/51

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

Adds a new field and functionality to the kadi `find_attitude` page.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

- [x] Run in real time during the 2022:231 CTU reset recovery around 3:44pm local Aug 20 with no date input.
- [x] Test with the date 2022:232:19:00:48.331 (after FFS commanded).
- [x] Entered a bunch of spaces in the `Star data` field and confirmed that MAUDE is used.
- [x] Run about 15 minutes after com and verified that the solution time corresponds to the last available time.

