### PR TITLE
Do not use timelines (via get_timeline_at_date)

### DIFF
--- a/kadi_apps/blueprints/pcad_acq/pcad_table.py
+++ b/kadi_apps/blueprints/pcad_acq/pcad_table.py
@@ -121,9 +121,7 @@ def get_acq_table(obsid):
     # Get the catalog for the stars
     # This is used both to map ACQID to the right slot and
     # to get the star positions to estimate deltas later
-    timeline_at_acq = mica.starcheck.starcheck.get_timeline_at_date(manvr.start)
-    mp_dir = None if (timeline_at_acq is None) else timeline_at_acq["mp_dir"]
-    starcheck = mica.starcheck.get_starcheck_catalog(int(obsid), mp_dir=mp_dir)
+    starcheck = mica.starcheck.get_starcheck_catalog_at_date(manvr.start)
     if "cat" not in starcheck:
         raise ValueError("No starcheck catalog found for {}".format(obsid))
     catalog = Table(starcheck["cat"])


### PR DESCRIPTION
## Description

Remove dependence on the `timelines` table in `cmd_states.db3`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This change was functionally tested for the same change in mica https://github.com/sot/mica/pull/279/commits/fa123b67d3a57728fe8d12fe10e6dafaf0a46fef  with the following, run for both the current release and the test version:
```
>>> from mica.web.pcad_table import get_acq_table
>>> dat = get_acq_table(8008)
# Save to a pickle file
```
The outputs from the two different versions were compared and found to be equal.