### PR TITLE
Fix table object columns and rework testing/dev infrastructure

### DIFF
--- a/kadi_apps/app.py
+++ b/kadi_apps/app.py
@@ -5,6 +5,7 @@
 
 import logging
 import argparse
+import os
 
 from pathlib import Path
 
@@ -13,6 +14,9 @@ from flask_cors import CORS
 from kadi_apps.rendering import render_template
 
 import pyyaks.logger
+
+
+PORT = int(os.environ.get('KADI_APPS_PORT', 9123))
 
 
 def page_not_found(e):
@@ -93,7 +97,7 @@ def get_parser():
 def main():
     # this starts the development server
     args = get_parser().parse_args()
-    get_app(settings=args.settings).run(host='0.0.0.0')
+    get_app(settings=args.settings).run(host='0.0.0.0', port=PORT)
 
 
 if __name__ == "__main__":

--- a/kadi_apps/settings/devel.py
+++ b/kadi_apps/settings/devel.py
@@ -1,9 +1,15 @@
+import os
+from pathlib import Path
 
-PORT = 9000
+import kadi_apps
+
 DEBUG = True
 TESTING = False
 
-KADI_APPS_CONFIG_DIR = '/Users/javierg/SAO/flask_apps/api-data/web-kadi-test/config'
+KADI_APPS_CONFIG_DIR = os.environ.get(
+    "KADI_APPS_CONFIG_DIR",
+    str(Path(kadi_apps.__file__).parent / "tests" / "data" / "config"),
+)
 LOG_LEVEL = 'INFO'
 TOKEN_VERSION = (1, 0)
 

--- a/kadi_apps/settings/production.py
+++ b/kadi_apps/settings/production.py
@@ -1,4 +1,3 @@
-PORT = 9000
 DEBUG = False
 TESTING = False
 

--- a/kadi_apps/settings/test.py
+++ b/kadi_apps/settings/test.py
@@ -1,5 +1,4 @@
 
-PORT = 9000
 DEBUG = True
 TESTING = False
 

--- a/kadi_apps/settings/unit_test.py
+++ b/kadi_apps/settings/unit_test.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 
-PORT = 9000
+import kadi_apps
+
 DEBUG = True
 TESTING = False
 
-KADI_APPS_CONFIG_DIR = str(Path(__file__).parent.parent / 'tests' / 'data' / 'config')
+KADI_APPS_CONFIG_DIR = str(Path(kadi_apps.__file__).parent / 'tests' / 'data' / 'config')
 LOG_LEVEL = 'INFO'
 TOKEN_VERSION = (1, 0)

--- a/kadi_apps/tests/test_astromon.py
+++ b/kadi_apps/tests/test_astromon.py
@@ -1,6 +1,10 @@
 import json
 import requests
 import numpy as np
+import pytest
+
+# Astromon is not currently installed as an app so do not test
+pytest.skip(allow_module_level=True)
 
 
 def test_matches(test_server):


### PR DESCRIPTION
## Description

In the course of fixing #17, I found a number of issues in trying to develop and test a fix:
- Port 5000 was hardwired (the flask default) but some app on my Mac was using that already.
- The [settings configuration](https://github.com/sot/kadi-apps/wiki/Developing-and-Testing-apps#kadi-apps-configuration) was awkward and I found it pretty confusing.
- In the settings a `PORT` was defined but it didn't seem to be used anywhere.
- Starting the flask server takes 10-12 seconds on my machine, but the unit tests were only allowing for about 8 seconds. The error message at the end (basically "could not start the server") was not helpful for me. (Though admittedly diagnosing the original timeout problem is not helped by the full traceback).
- The astromon app is apparently not installed so I skipped all the tests.

This PR adds two new potential environment variables to configure things:

- `KADI_APPS_PORT` to set the port number
- `KADI_APPS_CONFIG_DIR` to set the configuration settings directory. For the development and unit tests this defaults to a built-in directory so tests and the devel server should run out of the box without needing to copy anything from a special directory on HEAD.

Fixes #17 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None as far as I know.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac*

* `test_ska_api` is passing. `test_auth` is failing but I *think* that is unrelated to this PR, but this obviously needs checking.

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Replicated the unit test for `get_states` in a browser window and got reasonable results.
