### PR TITLE
renamed "production" settings to "flight"

### DIFF
--- a/kadi_apps/settings/flight.py
+++ b/kadi_apps/settings/flight.py
@@ -1,6 +1,6 @@
 import datetime
 
-# PORT is not set in production
+# PORT is not set in flight
 DEBUG = False
 TESTING = False
 


### PR DESCRIPTION
This is a trivial change: renamed "production" settings to "flight" to agree with our standard configuration in web-kadi. This will make the configuration in web-kadi a bit more straight-forward.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
replaces a module that is only used in web-kadi.

## Testing
I was hoping I could just merge this as is, considering the change is simple.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
