### PR TITLE
Add html form pieces to support find_attitude >= 3.5.0 Constraints

### DIFF
--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -75,21 +75,19 @@ def get_telem_from_maude(date=None):
 
     tbl = Table()
     tbl['slot'] = np.arange(8)
+    tbl["AOACFCT"] = [out[f"AOACFCT{ii}"] for ii in range(8)]
     tbl["AOACFID"] = [out[f"AOACFID{ii}"] for ii in range(8)]
     tbl['YAG'] = [out[f"AOACYAN{ii}"] for ii in range(8)]
     tbl['ZAG'] = [out[f"AOACZAN{ii}"] for ii in range(8)]
     tbl['MAG_ACA'] = [out[f"AOACMAG{ii}"] for ii in range(8)]
 
-    # Cut fid lights if explicitly labeled as such
-    tbl = tbl[(tbl["AOACFID"] != "FID")]
+    # Cut fid lights and non-tracking centroids
+    tbl = tbl[(tbl["AOACFID"] != "FID") & (tbl["AOACFCT"] == "TRAK")]
 
-    # Remove the fid light column
-    tbl = tbl["slot", "YAG", "ZAG", "MAG_ACA"]
+    # Remove the fid light and track columns as not needed for display
+    tbl.remove_columns(["AOACFID", "AOACFCT"])
 
-    # Filter out centroids if position and magnitude indicate not tracking
-    tbl = tbl[(tbl['MAG_ACA'] != 13.94) & (tbl['YAG'] != -3276.80) & (tbl['ZAG'] != -3276.80)]
-
-    date_ref = CxoTime(results[0]['times'][0]).date
+    # Save the date with the table metadata
     tbl.meta['date_solution'] = date_ref
 
     quat = Quat(q=[out[f"AOATTQT{ii}"] for ii in [1, 2, 3, 4]])

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -69,11 +69,16 @@ def get_telem_from_maude(date=None):
     tbl['YAG'] = [out[f"AOACYAN{ii}"] for ii in range(8)]
     tbl['ZAG'] = [out[f"AOACZAN{ii}"] for ii in range(8)]
     tbl['MAG_ACA'] = [out[f"AOACMAG{ii}"] for ii in range(8)]
-    tbl.meta['date_solution'] = CxoTime(results[0]['times'][-1]).date
+
+    # Filter out centroids if position and magnitude indicate not tracking
+    tbl = tbl[(tbl['MAG_ACA'] != 13.94) & (tbl['YAG'] != -3276.80) & (tbl['ZAG'] != -3276.80)]
+
+    date_ref = CxoTime(results[0]['times'][0]).date
+    tbl.meta['date_solution'] = date_ref
 
     quat = Quat(q=[out[f"AOATTQT{ii}"] for ii in [1, 2, 3, 4]])
 
-    return CxoTime(results[0]['times'][-1]).date, tbl, quat
+    return date_ref, tbl, quat
 
 
 

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -16,6 +16,7 @@ from Quaternion import normalize
 from kadi_apps.rendering import render_template
 
 POSSIBLE_CONSTRAINTS = ["pitch", "pitch_err",
+                        "att", "att_err",
                         "off_nom_roll_max",
                         "min_stars",
                         "mag_err"]
@@ -99,7 +100,10 @@ def get_constraints_from_form(form):
             if form_val == "":
                 form_val = None
             else:
-                form_val = float(form_val)
+                if constraint == 'att':
+                    form_val = normalize([float(val) for val in form_val.split(",")])
+                else:
+                    form_val = float(form_val)
         if form_val is not None:
             constraints[constraint] = form_val
 

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -250,13 +250,14 @@ def find_solutions_and_get_context(action):
                'summary': os.linesep.join(summary_lines)}
         sol["date"] = date
         pitch, off_nominal_roll = get_sol_pitch_roll(solution['att_fit'], date)
-        sol['pitch'] = f"{pitch:.3f}"
-        sol['roll'] = f"{off_nominal_roll:.3f}"
+        sol['pitch'] = pitch
+        sol['roll'] = off_nominal_roll
         if att_est is not None:
             sol["att_est"] = att_est
             att_est_dq = att_est.dq(solution['att_fit'])
             sol["dyaw"] = att_est_dq.yaw
             sol["dpitch"] = att_est_dq.pitch
+            sol["droll"] = att_est_dq.roll
 
         context['solutions'].append(sol)
 

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -167,7 +167,8 @@ def find_solutions_and_get_context():
         fa_constraints = None
 
     # Save the inputs for debugging
-    context["inputs"] = f"{stars} \n tolerance={tolerance} \n constraints={constraints} \n version={find_attitude.__version__}"
+    context["inputs"] = f"{stars} \n tolerance={tolerance} \n constraints={constraints}"
+    context["find_attitude_version"] = find_attitude.__version__
 
     try:
         solutions = find_attitude_solutions(stars, tolerance=tolerance, constraints=fa_constraints)

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -297,8 +297,11 @@ def find_solutions_and_get_context(action):
             sol["att_est"] = att_est
             att_est_dq = att_est.dq(solution['att_fit'])
             sol["dyaw"] = att_est_dq.yaw
+            sol["dyaw_arcsec"] = att_est_dq.yaw * 3600
             sol["dpitch"] = att_est_dq.pitch
+            sol["dpitch_arcsec"] = att_est_dq.pitch * 3600
             sol["droll"] = att_est_dq.roll0
+            sol["droll_arcsec"] = att_est_dq.roll0 * 3600
 
         context['solutions'].append(sol)
 

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -46,15 +46,14 @@ blueprint = Blueprint(
 
 def get_telem_from_maude(date=None):
 
-
     msids = []
     for msid_root in ["aoacfct", "aoacfid", "aoacyan", "aoaczan", "aoacmag"]:
         msids.extend([f"{msid_root}{ii}" for ii in range(8)])
     msids.extend(["aoattqt1", "aoattqt2", "aoattqt3", "aoattqt4"])
 
     if date is not None:
-        start = CxoTime(date)
-        stop = start + 10 * u.s
+        start = CxoTime(date) - 2 * u.s
+        stop = start + 12 * u.s
         kwargs = {'start': start, 'stop': stop}
     else:
         kwargs = {}

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -225,7 +225,12 @@ def find_solutions_and_get_context(action):
 
     if action == 'calc_solution_constraints':
         # And get the constraints for Constraints class
-        constraints = get_constraints_from_form(request.form)
+        try:
+            constraints = get_constraints_from_form(request.form)
+        except Exception as err:
+            context['error_message'] = (f"Error: {err}",
+                                        "Malformed constraints.")
+            return context
         fa_constraints = find_attitude.Constraints(**constraints)
         context["inputs"] = f"{stars} \n tolerance={tolerance} \n constraints={constraints}"
     else:

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -257,7 +257,7 @@ def find_solutions_and_get_context(action):
             att_est_dq = att_est.dq(solution['att_fit'])
             sol["dyaw"] = att_est_dq.yaw
             sol["dpitch"] = att_est_dq.pitch
-            sol["droll"] = att_est_dq.roll
+            sol["droll"] = att_est_dq.roll0
 
         context['solutions'].append(sol)
 

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -148,8 +148,7 @@ def get_constraints_from_form(form):
                     form_val = normalize([float(val) for val in form_val.split(",")])
                 else:
                     form_val = float(form_val)
-        if form_val is not None:
-            constraints[constraint] = form_val
+        constraints[constraint] = form_val
 
     date = form.get('date_solution', '').strip() or None
     constraints['date'] = date

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -197,17 +197,18 @@ def find_solutions_and_get_context(action):
             stars = get_stars_from_text(stars_text)
             context['date_solution'] = date_solution
         except Exception as err:
-            context['error_message'] = ("{}\n"
-                                        "Does it look like the example?"
-                                        .format(err))
+            context['error_message'] = (f"{err}\n"
+                                        "Does it look like the example?")
             return context
 
         att_est_text = request.form.get("att", "").strip() or None
         if att_est_text:
             try:
                 att_est = Quat(q=[float(val) for val in att_est_text.split(",")])
-            except Exception:
-                pass
+            except Exception as err:
+                context['error_message'] = (f"{err}\n",
+                                            "Malformed estimated attitude quaternion.")
+                return context
 
     if action == 'gettelem':
         # don't continue to get the solution, just return with the updated context

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -66,11 +66,11 @@ def get_telem_from_maude(date=None):
     out = {}
     for result in results:
         msid = result["msid"]
-        values = result["values"]
+        values = np.array(result["values"])
         if len(values) == 0:
             raise ValueError(f"No data for {msid} in time range date={date} start={start} stop={stop}")
-        if msid.startswith("aoacyan", "aoaczan", "aoacmag"):
-            if len(result["values"]) < 6:
+        if msid.lower().startswith(("aoacyan", "aoaczan", "aoacmag")):
+            if len(values) < 6:
                 value = np.median(values)
             else:
                 values = np.sort(values)

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -224,6 +224,7 @@ def find_solutions_and_get_context(action):
                                         "Does it look like the example?")
             return context
 
+
         att_est_text = request.form.get("att", "").strip() or None
         if att_est_text:
             try:
@@ -283,9 +284,9 @@ def find_solutions_and_get_context(action):
     context['solutions'] = []
     for solution in solutions:
         tbl = solution['summary']
-        tbl['YAG'].format = '.2f'
-        tbl['ZAG'].format = '.2f'
-        tbl['MAG_ACA'].format = '.2f'
+        for col in ['YAG', 'ZAG', 'MAG_ACA']:
+            if col in tbl.colnames:
+                tbl[col].format = '.2f'
         summary_lines = tbl.pformat(max_width=-1, max_lines=-1)
         sol = {'att_fit': solution['att_fit'],
                'summary': os.linesep.join(summary_lines)}

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -112,6 +112,11 @@ def index():
     else:
         context = {}
 
+    local_tz = pytz.timezone('America/New_York')
+    local_time = datetime.datetime.now(local_tz)
+    generation_time = local_time.strftime("%I:%M:%S%p %Z on %Y-%m-%d")
+
+    context['generation_time'] = generation_time
     context['kadi_version'] = __version__
 
     # Update some constraints to their default values if not set.
@@ -266,11 +271,6 @@ def find_solutions_and_get_context(action):
     date = context.get("date_solution", None)
     date = CxoTime(date) if date else CxoTime.now()
 
-    # Save time solution was calulate as a string in local time with AM/PM
-    # Replace 'America/New_York' with your local time zone
-    local_tz = pytz.timezone('America/New_York')
-    local_time = datetime.datetime.now(local_tz)
-    generation_time = local_time.strftime("%I:%M:%S%p %Z on %Y-%m-%d")
 
     context['solutions'] = []
     for solution in solutions:
@@ -292,7 +292,6 @@ def find_solutions_and_get_context(action):
             sol["dpitch"] = att_est_dq.pitch
             sol["droll"] = att_est_dq.roll0
 
-        sol['generation_time'] = generation_time
         context['solutions'].append(sol)
 
     return context

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -168,14 +168,19 @@ def find_solutions_and_get_context(action):
 
         # Get a formatted version of the stars table that is used for finding
         # the solutions. This gets put back into the web page output.
-        out = StringIO()
-        stars_context = stars.copy()
-        cols_new = ['yag', 'zag', 'mag']
-        stars_context.rename_columns(['YAG', 'ZAG', 'MAG_ACA'], cols_new)
-        for name in cols_new:
-            stars_context[name].format = '.2f'
-        stars_context.write(out, format='ascii.fixed_width', delimiter=' ')
-        context['stars_text'] = out.getvalue()
+        if len(stars) == 0:
+            context["stars_text"] = "No tracked stars."
+        else:
+            out = StringIO()
+            stars_context = stars.copy()
+            cols_new = ['yag', 'zag', 'mag']
+            stars_context.rename_columns(['YAG', 'ZAG', 'MAG_ACA'], cols_new)
+            for name in cols_new:
+                stars_context[name].format = '.2f'
+            stars_context.write(out, format='ascii.fixed_width', delimiter=' ')
+            context['stars_text'] = out.getvalue()
+
+
         context['date_solution'] = date
         context['att'] = f"{att_est.q[0]:.8f}, {att_est.q[1]:.8f}, {att_est.q[2]:.8f}, {att_est.q[3]:.8f}"
 
@@ -193,7 +198,7 @@ def find_solutions_and_get_context(action):
             context['date_solution'] = date_solution
         except Exception as err:
             context['error_message'] = ("{}\n"
-                                        "Does it look like one of the examples?"
+                                        "Does it look like the example?"
                                         .format(err))
             return context
 

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -57,7 +57,7 @@ def get_telem_from_maude(date=None):
     stop = None
     if date is not None:
         start = CxoTime(date) - 5 * u.s
-        stop = start + 12 * u.s
+        stop = start + 10 * u.s
         kwargs = {'start': start, 'stop': stop}
     else:
         kwargs = {}
@@ -85,7 +85,7 @@ def get_telem_from_maude(date=None):
     # one of those is used, an attempt to refetch the data based on
     # one of those times can fail for the case where one is working with
     # the last of the realtime telemetry.
-    date_ref = CxoTime(np.mean(results[0]['times'])).date
+    date_ref = CxoTime(np.median(results[0]['times'])).date
 
     tbl = Table()
     tbl['slot'] = np.arange(8)

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -47,6 +47,7 @@ def get_telem_from_maude(date=None):
 
 
     msids = ["aoattqt1", "aoattqt2", "aoattqt3", "aoattqt4"]
+    msids.extend([f"aoacfid{ii}" for ii in range(8)])
     msids.extend([f"aoacyan{ii}" for ii in range(8)])
     msids.extend([f"aoaczan{ii}" for ii in range(8)])
     msids.extend([f"aoacmag{ii}" for ii in range(8)])
@@ -66,9 +67,16 @@ def get_telem_from_maude(date=None):
 
     tbl = Table()
     tbl['slot'] = np.arange(8)
+    tbl["AOACFID"] = [out[f"AOACFID{ii}"] for ii in range(8)]
     tbl['YAG'] = [out[f"AOACYAN{ii}"] for ii in range(8)]
     tbl['ZAG'] = [out[f"AOACZAN{ii}"] for ii in range(8)]
     tbl['MAG_ACA'] = [out[f"AOACMAG{ii}"] for ii in range(8)]
+
+    # Cut fid lights if explicitly labeled as such
+    tbl = tbl[(tbl["AOACFID"] != "FID")]
+
+    # Remove the fid light column
+    tbl = tbl["slot", "YAG", "ZAG", "MAG_ACA"]
 
     # Filter out centroids if position and magnitude indicate not tracking
     tbl = tbl[(tbl['MAG_ACA'] != 13.94) & (tbl['YAG'] != -3276.80) & (tbl['ZAG'] != -3276.80)]

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -3,6 +3,7 @@ import os
 from io import StringIO
 import datetime
 from logging import CRITICAL
+import pprint
 
 import astropy.units as u
 import find_attitude
@@ -232,7 +233,7 @@ def find_solutions_and_get_context(action):
                                         "Malformed constraints.")
             return context
         fa_constraints = find_attitude.Constraints(**constraints)
-        context["inputs"] = f"{stars} \n tolerance={tolerance} \n constraints={constraints}"
+        context["inputs"] = f"{stars} \n tolerance={tolerance} \n constraints={pprint.pformat(constraints)}"
     else:
         fa_constraints = None
         context["inputs"] = f"{stars} \n tolerance={tolerance}"

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -1,17 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from io import StringIO
 import os
-
-from flask import Blueprint, request
-
-from cxotime import CxoTime
-import ska_sun
-from kadi import __version__
-import find_attitude
-from find_attitude.find_attitude import get_stars_from_text, find_attitude_solutions, logger
+from io import StringIO
 from logging import CRITICAL
-from kadi_apps.rendering import render_template
 
+import find_attitude
+import ska_sun
+from cxotime import CxoTime
+from find_attitude.find_attitude import (find_attitude_solutions,
+                                         get_stars_from_text, logger)
+from flask import Blueprint, request
+from kadi import __version__
+
+from kadi_apps.rendering import render_template
 
 POSSIBLE_CONSTRAINTS = ['pitch', 'pitch_err',
                         'off_nom_roll_max',
@@ -32,11 +32,11 @@ blueprint = Blueprint(
 
 
 def get_stars_from_maude(date=None):
-    from maude import get_msids
     import astropy.units as u
-    from cxotime import CxoTime
-    from astropy.table import Table
     import numpy as np
+    from astropy.table import Table
+    from cxotime import CxoTime
+    from maude import get_msids
 
     msids = []
     msids.extend([f"aoacyan{ii}" for ii in range(8)])

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -2,6 +2,7 @@
 import os
 from io import StringIO
 import datetime
+import pytz
 from logging import CRITICAL
 import pprint
 
@@ -267,7 +268,10 @@ def find_solutions_and_get_context(action):
     date = CxoTime(date) if date else CxoTime.now()
 
     # Save time solution was calulate as a string in local time with AM/PM
-    generation_time = f"{datetime.datetime.now():%I:%M:%S%p on %Y-%m-%d}"
+    # Replace 'America/New_York' with your local time zone
+    local_tz = pytz.timezone('America/New_York')
+    local_time = datetime.datetime.now(local_tz)
+    generation_time = local_time.strftime("%I:%M:%S%p %Z on %Y-%m-%d")
 
     context['solutions'] = []
     for solution in solutions:

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -215,7 +215,7 @@ def find_solutions_and_get_context(action):
     # No solutions, bummer.
     if not solutions:
         context['error_message'] = ('No matching solutions found.\n'
-                                    'Try increasing distance tolerance.')
+                                    'Try increasing distance tolerance or relaxing optional constraints (if applied).')
         return context
 
     # Reference date

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -13,10 +13,10 @@ from kadi import __version__
 
 from kadi_apps.rendering import render_template
 
-POSSIBLE_CONSTRAINTS = ['pitch', 'pitch_err',
-                        'off_nom_roll_max',
-                        'min_stars',
-                        'mag_err']
+POSSIBLE_CONSTRAINTS = ["pitch", "pitch_err",
+                        "off_nom_roll_max",
+                        "min_stars",
+                        "mag_err"]
 
 # Only emit critical messages
 logger.level = CRITICAL
@@ -94,7 +94,7 @@ def get_constraints_from_form(form):
         form_val = form.get(constraint)
         if form_val is not None:
             form_val = form_val.strip()
-            if form_val == '':
+            if form_val == "":
                 form_val = None
             else:
                 form_val = float(form_val)
@@ -161,7 +161,7 @@ def find_solutions_and_get_context():
         fa_constraints = None
 
     # Save the inputs for debugging
-    context['inputs'] = f"{stars} \n tolerance={tolerance} \n constraints={constraints} \n version={find_attitude.__version__}"
+    context["inputs"] = f"{stars} \n tolerance={tolerance} \n constraints={constraints} \n version={find_attitude.__version__}"
 
     try:
         solutions = find_attitude_solutions(stars, tolerance=tolerance, constraints=fa_constraints)
@@ -177,7 +177,7 @@ def find_solutions_and_get_context():
         return context
 
     # Reference date
-    date = context.get('date_solution', None)
+    date = context.get("date_solution", None)
     date = CxoTime(date) if date else CxoTime.now()
 
     context['solutions'] = []
@@ -189,8 +189,8 @@ def find_solutions_and_get_context():
         summary_lines = tbl.pformat(max_width=-1, max_lines=-1)
         sol = {'att_fit': solution['att_fit'],
                'summary': os.linesep.join(summary_lines)}
-        sol['date'] = date
-        sol['pitch'], sol['roll'] = get_sol_pitch_roll(solution['att_fit'], date)
+        sol["date"] = date
+        sol["pitch"], sol["roll"] = get_sol_pitch_roll(solution['att_fit'], date)
         context['solutions'].append(sol)
 
     return context

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -21,7 +21,7 @@ from Quaternion import Quat, normalize
 
 from kadi_apps.rendering import render_template
 
-DEFAULT_CONSTRAINTS = {'distance_tolerance': 2.5,
+DEFAULT_CONSTRAINTS = {'distance_tolerance': 3.0,
             'pitch_err': 1.5,
             'att_err': 4.0,
             'mag_err': 1.5,

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -46,11 +46,11 @@ blueprint = Blueprint(
 def get_telem_from_maude(date=None):
 
 
-    msids = ["aoattqt1", "aoattqt2", "aoattqt3", "aoattqt4"]
-    msids.extend([f"aoacfid{ii}" for ii in range(8)])
-    msids.extend([f"aoacyan{ii}" for ii in range(8)])
-    msids.extend([f"aoaczan{ii}" for ii in range(8)])
-    msids.extend([f"aoacmag{ii}" for ii in range(8)])
+    msids = []
+    for msid_root in ["aoacfct", "aoacfid", "aoacyan", "aoaczan", "aoacmag"]:
+        msids.extend([f"{msid_root}{ii}" for ii in range(8)])
+    msids.extend(["aoattqt1", "aoattqt2", "aoattqt3", "aoattqt4"])
+
     if date is not None:
         start = CxoTime(date)
         stop = start + 10 * u.s
@@ -64,6 +64,14 @@ def get_telem_from_maude(date=None):
         msid = result["msid"]
         value = result["values"][-1]
         out[msid] = value
+
+    # Use the time of one of the ACA msids to determine the reference time.
+    # result[0] should be AOACFCT0.
+    # The quaternions are sampled more frequently so if the last time of
+    # one of those is used, an attempt to refetch the data based on
+    # one of those times can fail for the case where one is working with
+    # the last of the realtime telemetry.
+    date_ref = CxoTime(results[0]['times'][-1]).date
 
     tbl = Table()
     tbl['slot'] = np.arange(8)

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 from io import StringIO
+import datetime
 from logging import CRITICAL
 
 import astropy.units as u
@@ -256,6 +257,9 @@ def find_solutions_and_get_context(action):
     date = context.get("date_solution", None)
     date = CxoTime(date) if date else CxoTime.now()
 
+    # Save time solution was calulate as a string in local time with AM/PM
+    generation_time = f"{datetime.datetime.now():%I:%M:%S%p on %Y-%m-%d}"
+
     context['solutions'] = []
     for solution in solutions:
         tbl = solution['summary']
@@ -276,6 +280,7 @@ def find_solutions_and_get_context(action):
             sol["dpitch"] = att_est_dq.pitch
             sol["droll"] = att_est_dq.roll0
 
+        sol['generation_time'] = generation_time
         context['solutions'].append(sol)
 
     return context

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -117,6 +117,9 @@ def get_constraints_from_form(form):
         if form_val is not None:
             constraints[constraint] = form_val
 
+    date = form.get('date_solution', '').strip() or None
+    constraints['date'] = date
+
     return constraints
 
 

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -2,14 +2,16 @@
 import os
 from io import StringIO
 from logging import CRITICAL
+from flask import Blueprint, request
 
-import find_attitude
-import ska_sun
+
 from cxotime import CxoTime
+import find_attitude
 from find_attitude.find_attitude import (find_attitude_solutions,
                                          get_stars_from_text, logger)
-from flask import Blueprint, request
 from kadi import __version__
+import ska_sun
+from Quaternion import normalize
 
 from kadi_apps.rendering import render_template
 

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -167,10 +167,23 @@ class="with-background"
       </p>
     </div>
   </div>
-  <pre>
   <h4> Star match summary and residuals </h4>
+  <pre>
 {{ solution.summary }}
   </pre>
+  <h4>Distance from solution to onboard estimated attitude</h4>
+  <p>
+    dyaw {{solution.dyaw}} <br>
+    dpitch {{solution.dpitch}} <br>
+  </p>
+  <strong>Onboard estimated attitude</strong>
+  <p>
+    RA={{solution.att_est.ra}} <br>
+    Dec={{solution.att_est.dec}} <br>
+    Roll={{solution.att_est.roll}} <br>
+  </p>
+  <p></p>
+
   {% endfor %}
 
 <P><B>Supplied find_attitude Inputs</B></P>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -62,7 +62,7 @@ class="with-background"
       style="font-family:Consolas,Monaco,Lucida Console,Liberation
                Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,
                monospace;"
-        rows="10" cols="80" name="stars_text">{{stars_text}}</textarea>
+        rows="9" cols="80" name="stars_text">{{stars_text}}</textarea>
     </div>
     </div>
   </div>
@@ -121,9 +121,6 @@ class="with-background"
 </form>
 <br style="clear:both;"/>
 </div>
-
-<br></br>
-<br></br>
 
 {% if error_message %}
   <h2> ERROR </h2>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -14,6 +14,8 @@ class="with-background"
 
 </form>
 
+
+
 <div class="row">
     <div class="large-12 columns">
         <p>Choose one of the following options:
@@ -25,15 +27,19 @@ class="with-background"
                 <li> Enter a date to get the solution at a particular time. </li>
                 <li> Leave the date blank to get the solution at the current time.</li>
             </ul>
+            <li> Run find_attitude with or without constraints</li>
         </ul>
         <br>
-        Click Submit and wait for up to a minute for the attitude solution
-        results.
         </p>
     </div>
 </div>
 
+
+
 <form action="/find_attitude/" method="post">
+
+  <button type="submit" name="action" value="gettelem">Get Telem</button>
+
 
   <div class="row">
     <div class="col">
@@ -61,7 +67,12 @@ class="with-background"
         rows="10" cols="80" name="stars_text">{{stars_text}}</textarea>
     </div>
   </div>
-  &nbsp;
+
+  <button type="submit" name="action" value="calc_solution">Find Attitude (no constraints)</button>
+
+  <br></br>
+  <br></br>
+
   <P><B>Optional Constraints:</B></P>
   <div class="row">
     <div class="col">
@@ -69,13 +80,13 @@ class="with-background"
       <input type="text" class="form-control" id="pitch" name="pitch" value="{{pitch}}">
     </div>
     <div class="col">
-      <label for="pitch_err">Pitch Error (degrees) (default 1.5)</label>
+      <label for="pitch_err">Pitch Error (degrees))</label>
       <input type="text" class="form-control" id="pitch_err" name="pitch_err" value="{{pitch_err}}">
     </div>
   </div>
   <div class="row">
     <div class="col">
-      <label for="off_nom_roll_max">Max Off-Nominal Roll (degrees) (default 2.0 if there are any constraints)</label>
+      <label for="off_nom_roll_max">Max Off-Nominal Roll (degrees)</label>
       <input type="text" class="form-control" id="off_nom_roll_max" name="off_nom_roll_max" value="{{off_nom_roll_max}}">
     </div>
   </div>
@@ -87,7 +98,7 @@ class="with-background"
   </div>
   <div class="row">
     <div class="col">
-      <label for="att_err">Attitude Error (default 4.0)</label>
+      <label for="att_err">Attitude Error</label>
       <input type="text" class="form-control" id="att_err" name="att_err" value="{{att_err}}">
     </div>
   </div>
@@ -99,17 +110,16 @@ class="with-background"
   </div>
   <div class="row">
     <div class="col">
-      <label for="mag_err">Faint mag threshold for filtering pairs (default 1.5)</label>
+      <label for="mag_err">Faint mag threshold for filtering pairs</label>
       <input type="text" class="form-control" id="mag_err" name="mag_err" value="{{mag_err}}">
     </div>
   </div>
-  &nbsp;
-  <div class="row">
-    <div class="col">
-      <input type="submit" value="Submit">
-    </div>
-  </div>
+  <button type="submit" name="action" value="calc_solution_constraints">Find Attitude with Constraints</button>
+
 </form>
+
+<br></br>
+<br></br>
 
 {% if error_message %}
   <h2> ERROR </h2>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -142,8 +142,8 @@ class="with-background"
   <p> Distance tolerance: {{ distance_tolerance }} arcsec. </p>
 
   <P>Date for Pitch/Roll: {{ solution.date }}<br>
-  Sun Pitch: {{ "%.3f" | format(solution.pitch) }}<br>
-  Off-Nominal Roll: {{ "%.3f" | format(solution.roll) }}</P>
+  Sun Pitch: {{ "%.3f" | format(solution.pitch|float) }}<br>
+  Off-Nominal Roll: {{ "%.3f" | format(solution.roll|float) }}</P>
 
   <h4> Coordinates </h4>
 
@@ -189,7 +189,7 @@ class="with-background"
   {% endfor %}
 
 <P><B>Supplied find_attitude Inputs</B></P>
-<pre>{{ inputs}}</pre>
+<pre>{{inputs}}</pre>
 
 <P>find_attitude version: {{find_attitude_version}}</P>
 

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -171,6 +171,7 @@ class="with-background"
   <pre>
 {{ solution.summary }}
   </pre>
+  {% if solution.att_est %}
   <h4>Distance from solution to onboard estimated attitude</h4>
   <p>
     dyaw {{solution.dyaw}} <br>
@@ -182,6 +183,7 @@ class="with-background"
     Dec={{solution.att_est.dec}} <br>
     Roll={{solution.att_est.roll}} <br>
   </p>
+  {% endif %}
   <p></p>
 
   {% endfor %}

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -169,9 +169,9 @@ class="with-background"
   {% if solution.att_est %}
   <h4>Distance from solution to onboard estimated attitude</h4>
   <p>
-    dyaw={{ "%.5f" | format(solution.dyaw) }} degrees<br>
-    dpitch={{ "%.5f" | format(solution.dpitch) }} degrees<br>
-    droll={{ "%.5f" | format(solution.droll) }} degrees<br>
+    dyaw={{ "%.5f" | format(solution.dyaw) }} degrees ({{ "%.1f" | format(solution.dyaw_arcsec) }} arcsec)<br>
+    dpitch={{ "%.5f" | format(solution.dpitch) }} degrees ({{ "%.1f" | format(solution.dpitch_arcsec) }} arcsec)<br>
+    droll={{ "%.5f" | format(solution.droll) }} degrees ({{ "%.1f" | format(solution.droll_arcsec) }} arcsec)<br>
   </p>
   <strong>Estimated attitude</strong>
   <p>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -20,8 +20,7 @@ class="with-background"
     <div class="large-12 columns">
         <p>Choose one of the following options:
         <ul>
-            <li> Enter ACA star data below using either GRETA display A_ACA_ALL
-                or as a simple text table.</li>
+            <li> Enter ACA star data below as a simple text table.</li>
             <li> Leave the Star data field blank and use MAUDE to fetch ACA star data.</li>
             <ul>
                 <li> Enter a date to get the solution at a particular time. </li>
@@ -195,27 +194,7 @@ class="with-background"
 
 {% else %}
   <h2> Example inputs </h2>
-  <h3> GRETA copy/paste </h3>
-<pre>
-Northrop Grumman/FOT Decom v1.2                                                             SC:2015007.060558  Fri Feb 27 17:35:04 2015
-COMMAND>
-                                     PCAD MODE   NPNT     TLM FORMAT   FMT2       CTU VCDU   2156840     AODITHEN        DISA
-ASPECT CAMERA TELEMETRY              AOCONLAW    NPNT     TLM SUBFMT   NORM       OBC VCDU   2156832     AODITHR1  0.0000e+00
-                                     AOABERRN    DISA     AOFATTUP     NONE       AOETIMEX 473925968     AODITHR2  0.0000e+00
-     OBSID      0                    AOACINTT  704.688    AOACPRGS        0       AOCINTNP      ENAB     AODITHR3  0.0000e+00
 
-                                                                        AOFWAIT  NOWT      Acquisition
-   ACA     IMAGE Status  Image   Fid Lt      Centroid Angle     Star    AOACASEQ KALM        Success        GLOBAL STATUS
-   MEAS      #   Flags   Functn  Flag        Y         Z        Mag     AOFSTAR  BRIT     AORFSTR1    6     AOACPWRF   OK
-  IMAGE 0  0     STAR    TRAK   STAR     -381.28    1479.95      7.2    AONSTARS    7     AORFSTR2    7     AOACRAMF   OK
-  IMAGE 1  1     STAR    TRAK   STAR     -582.55    -830.85      8.9    AOKALSTR    7                       AOACROMF   OK
-  IMAGE 2  2     STAR    TRAK   STAR     2076.33   -2523.10      8.5                      ENTRY 0    ID     AOACSUMF   OK
-  IMAGE 3  3     STAR    TRAK   STAR     -498.12    -958.33      5.0    SUCCESS FLAGS     ENTRY 1  NOID     AOACHIBK   OK
-  IMAGE 4  4     STAR    TRAK   STAR     -431.68    1600.98      8.2    AOACQSUC NSUC     ENTRY 2    ID
-  IMAGE 5  5     STAR    TRAK   STAR     -282.40     980.50      7.9    AOGDESUC NSUC     ENTRY 3    ID     AOACCALF   OK
-  IMAGE 6  6     NULL    NONE   STAR    -3276.80   -3276.80     13.9    AOBRTSUC  SUC     ENTRY 4    ID     AOACRSET   OK
-  IMAGE 7  7     STAR    TRAK   STAR      573.25   -2411.70      7.1    AOFIDSUC NSUC     ENTRY 5    ID     AOACSNTY   OK
-</pre>
 <h3> Simple text table </h3>
 <pre>
 slot yag zag mag

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -75,21 +75,15 @@ class="with-background"
   </div>
 
   <div style="width: 50%; float: right;">
-  <P><B>Optional Constraints:</B></P>
+  <P><B>Optional Constraints to Limit Star Pair Candidates:</B></P>
   <div class="row">
     <div class="col">
       <label for="pitch">Sun Pitch</label>
       <input type="text" class="form-control" id="pitch" name="pitch" value="{{pitch}}">
     </div>
     <div class="col">
-      <label for="pitch_err">Pitch Error (degrees))</label>
+      <label for="pitch_err">Pitch Uncertainty (degrees)</label>
       <input type="text" class="form-control" id="pitch_err" name="pitch_err" value="{{pitch_err}}">
-    </div>
-  </div>
-  <div class="row">
-    <div class="col">
-      <label for="off_nom_roll_max">Max Off-Nominal Roll (degrees)</label>
-      <input type="text" class="form-control" id="off_nom_roll_max" name="off_nom_roll_max" value="{{off_nom_roll_max}}">
     </div>
   </div>
   <div class="row">
@@ -100,19 +94,25 @@ class="with-background"
   </div>
   <div class="row">
     <div class="col">
-      <label for="att_err">Attitude Error</label>
+      <label for="att_err">Radial Uncertainty in Estimated Attitude (degrees)</label>
       <input type="text" class="form-control" id="att_err" name="att_err" value="{{att_err}}">
     </div>
   </div>
   <div class="row">
     <div class="col">
-      <label for="min_stars">Min # of stars required (default via get_min_stars())</label>
+      <label for="off_nom_roll_max">Max Off-Nominal Roll (degrees)</label>
+      <input type="text" class="form-control" id="off_nom_roll_max" name="off_nom_roll_max" value="{{off_nom_roll_max}}">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <label for="min_stars">Min Required Stars (leave blank or discuss with ACA)</label>
       <input type="text" class="form-control" id="min_stars" name="min_stars" value="{{min_stars}}">
     </div>
   </div>
   <div class="row">
     <div class="col">
-      <label for="mag_err">Faint mag threshold for filtering pairs</label>
+      <label for="mag_err">Max Diff Between Observed - AGASC Star Mag</label>
       <input type="text" class="form-control" id="mag_err" name="mag_err" value="{{mag_err}}">
     </div>
   </div>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -137,7 +137,7 @@ class="with-background"
 
 {% if solutions %}
   {% for solution in solutions %}
-  <h2> Attitude solution </h2>
+  <h2> Attitude solution generated at {{ solution.generation_time }} </h2>
 
   <p> Distance tolerance: {{ distance_tolerance }} arcsec. </p>
 

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -75,7 +75,7 @@ class="with-background"
   </div>
   <div class="row">
     <div class="col">
-      <label for="off_nom_roll_max">Max Off-Nominal Roll (degrees) (default 2.0 if constrained)</label>
+      <label for="off_nom_roll_max">Max Off-Nominal Roll (degrees) (default 2.0 if there are any constraints)</label>
       <input type="text" class="form-control" id="off_nom_roll_max" name="off_nom_roll_max" value="{{off_nom_roll_max}}">
     </div>
   </div>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -27,10 +27,9 @@ class="with-background"
                 <li> Enter a date to get the solution at a particular time. </li>
                 <li> Leave the date blank to get the solution at the current time.</li>
             </ul>
-            <li> Run find_attitude with or without constraints</li>
         </ul>
-        <br>
-        </p>
+	</p>
+        <p>Then run find_attitude with or without constraints</p>
     </div>
 </div>
 

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -134,6 +134,8 @@ class="with-background"
     <h2> Attitude solution generated at {{ generation_time }} </h2>
 
   {% for solution in solutions %}
+  <hr></hr>
+  <h3> Solution {{ loop.index }} </h3>
 
   <p> Distance tolerance: {{ distance_tolerance }} arcsec. </p>
 

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -158,6 +158,11 @@ class="with-background"
   </pre>
   {% endfor %}
 
+<P><B>Supplied find_attitude Inputs</B></P>
+<pre>{{ inputs}}</pre>
+
+<P>find_attitude version: {{find_attitude_version}}</P>
+
 {% else %}
   <h2> Example inputs </h2>
   <h3> GRETA copy/paste </h3>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -81,6 +81,18 @@ class="with-background"
   </div>
   <div class="row">
     <div class="col">
+      <label for="att">Estimated Attitude (supply as q1, q2, q3, q4)</label>
+      <input type="text" class="form-control" id="att" name="att" value="{{att}}">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <label for="att_err">Attitude Error (default 4.0)</label>
+      <input type="text" class="form-control" id="att_err" name="att_err" value="{{att_err}}">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
       <label for="min_stars">Min # of stars required (default via get_min_stars())</label>
       <input type="text" class="form-control" id="min_stars" name="min_stars" value="{{min_stars}}">
     </div>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -78,11 +78,11 @@ class="with-background"
   <P><B>Optional Constraints to Limit Star Pair Candidates:</B></P>
   <div class="row">
     <div class="col">
-      <label for="pitch">Sun Pitch</label>
+      <label for="pitch">Sun Pitch (degrees)</label>
       <input type="text" class="form-control" id="pitch" name="pitch" value="{{pitch}}">
     </div>
     <div class="col">
-      <label for="pitch_err">Pitch Uncertainty (degrees)</label>
+      <label for="pitch_err">Sun Pitch Uncertainty (degrees)</label>
       <input type="text" class="form-control" id="pitch_err" name="pitch_err" value="{{pitch_err}}">
     </div>
   </div>
@@ -94,7 +94,7 @@ class="with-background"
   </div>
   <div class="row">
     <div class="col">
-      <label for="att_err">Radial Uncertainty in Estimated Attitude (degrees)</label>
+      <label for="att_err">Estimated Attitude Radial Uncertainty (degrees)</label>
       <input type="text" class="form-control" id="att_err" name="att_err" value="{{att_err}}">
     </div>
   </div>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -121,7 +121,7 @@ class="with-background"
 </div>
 
 {% if error_message %}
-  <h2> ERROR </h2>
+  <h2> ERROR generated at {{ generation_time }} </h2>
   <pre>
     {{ error_message }}
   </pre>
@@ -131,8 +131,9 @@ class="with-background"
 {% endif %}
 
 {% if solutions %}
+    <h2> Attitude solution generated at {{ generation_time }} </h2>
+
   {% for solution in solutions %}
-  <h2> Attitude solution generated at {{ solution.generation_time }} </h2>
 
   <p> Distance tolerance: {{ distance_tolerance }} arcsec. </p>
 

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -6,7 +6,7 @@ class="with-background"
 
 {% block content %}
 <p><p>
-<h1 align="center"> Find Chandra attitude from stars {{subtitle}}</h1>
+<h1 align="center" style="margin: 0px; padding: 0px;"> Find Chandra attitude from stars {{subtitle}}</h1>
 
 
 <form action="" method="get">
@@ -14,14 +14,12 @@ class="with-background"
 
 </form>
 
-
-
 <div class="row">
     <div class="large-12 columns">
         <p>Choose one of the following options:
         <ul>
             <li> Enter ACA star data below as a simple text table.</li>
-            <li> Leave the Star data field blank and use MAUDE to fetch ACA star data.</li>
+            <li> Leave the Star data field blank and use MAUDE with the Get Telem button to fetch ACA star data.</li>
             <ul>
                 <li> Enter a date to get the solution at a particular time. </li>
                 <li> Leave the date blank to get the solution at the current time.</li>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -142,26 +142,26 @@ class="with-background"
   <p> Distance tolerance: {{ distance_tolerance }} arcsec. </p>
 
   <P>Date for Pitch/Roll: {{ solution.date }}<br>
-  Sun Pitch: {{ solution.pitch }}<br>
-  Off-Nominal Roll: {{ solution.roll }}</P>
+  Sun Pitch: {{ "%.3f" | format(solution.pitch) }}<br>
+  Off-Nominal Roll: {{ "%.3f" | format(solution.roll) }}</P>
 
   <h4> Coordinates </h4>
 
   <div class="row">
     <div class="large-3 columns">
       <p> <strong>
-          RA={{solution.att_fit.ra}} <br>
-          Dec={{solution.att_fit.dec}} <br>
-          Roll={{solution.att_fit.roll}} <br>
+          RA={{"%.4f" | format(solution.att_fit.ra)}} <br>
+          Dec={{"%.4f" | format(solution.att_fit.dec)}} <br>
+          Roll={{"%.4f" | format(solution.att_fit.roll)}} <br>
           </strong>
       </p>
     </div>
     <div class="large-3 columns end">
-      <p> <strong>
-          Q1={{solution.att_fit.q.0}} <br>
-          Q2={{solution.att_fit.q.1}} <br>
-          Q3={{solution.att_fit.q.2}} <br>
-          Q4={{solution.att_fit.q.3}} <br>
+      <p> <strong>Solution Quaternion: <br>
+        [{{"%.12f" | format(solution.att_fit.q.0)}},
+        {{"%.12f" | format(solution.att_fit.q.1)}},
+        {{"%.12f" | format(solution.att_fit.q.2)}},
+        {{"%.12f" | format(solution.att_fit.q.3)}}] <br>
           </strong>
       </p>
     </div>
@@ -173,14 +173,15 @@ class="with-background"
   {% if solution.att_est %}
   <h4>Distance from solution to onboard estimated attitude</h4>
   <p>
-    dyaw {{solution.dyaw}} <br>
-    dpitch {{solution.dpitch}} <br>
+    dyaw={{ "%.5f" | format(solution.dyaw) }} degrees<br>
+    dpitch={{ "%.5f" | format(solution.dpitch) }} degrees<br>
+    droll={{ "%.5f" | format(solution.droll) }} degrees<br>
   </p>
-  <strong>Onboard estimated attitude</strong>
+  <strong>Estimated attitude</strong>
   <p>
-    RA={{solution.att_est.ra}} <br>
-    Dec={{solution.att_est.dec}} <br>
-    Roll={{solution.att_est.roll}} <br>
+    RA={{"%.4f" | format(solution.att_est.ra)}} <br>
+    Dec={{"%.4f" | format(solution.att_est.dec)}} <br>
+    Roll={{"%.4f" | format(solution.att_est.roll)}} <br>
   </p>
   {% endif %}
   <p></p>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -62,6 +62,36 @@ class="with-background"
     </div>
   </div>
   &nbsp;
+  <P><B>Optional Constraints:</B></P>
+  <div class="row">
+    <div class="col">
+      <label for="pitch">Sun Pitch</label>
+      <input type="text" class="form-control" id="pitch" name="pitch" value="{{pitch}}">
+    </div>
+    <div class="col">
+      <label for="pitch_err">Pitch Error (degrees) (default 1.5)</label>
+      <input type="text" class="form-control" id="pitch_err" name="pitch_err" value="{{pitch_err}}">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <label for="off_nom_roll_max">Max Off-Nominal Roll (degrees) (default 2.0 if constrained)</label>
+      <input type="text" class="form-control" id="off_nom_roll_max" name="off_nom_roll_max" value="{{off_nom_roll_max}}">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <label for="min_stars">Min # of stars required (default via get_min_stars())</label>
+      <input type="text" class="form-control" id="min_stars" name="min_stars" value="{{min_stars}}">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <label for="mag_err">Faint mag threshold for filtering pairs (default 1.5)</label>
+      <input type="text" class="form-control" id="mag_err" name="mag_err" value="{{mag_err}}">
+    </div>
+  </div>
+  &nbsp;
   <div class="row">
     <div class="col">
       <input type="submit" value="Submit">
@@ -74,6 +104,9 @@ class="with-background"
   <pre>
     {{ error_message }}
   </pre>
+  <pre>
+    {{ inputs }}
+  </pre>
 {% endif %}
 
 {% if solutions %}
@@ -81,6 +114,10 @@ class="with-background"
   <h2> Attitude solution </h2>
 
   <p> Distance tolerance: {{ distance_tolerance }} arcsec. </p>
+
+  <P>Date for Pitch/Roll: {{ solution.date }}<br>
+  Sun Pitch: {{ solution.pitch }}<br>
+  Off-Nominal Roll: {{ solution.roll }}</P>
 
   <h4> Coordinates </h4>
 

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -34,13 +34,13 @@ class="with-background"
 </div>
 
 
-
+<div id="form">
 <form action="/find_attitude/" method="post">
 
+  <div style="width: 50%; float: left;">
   <button type="submit" name="action" value="gettelem">Get Telem</button>
-
-
   <div class="row">
+    <div class="col">
     <div class="col">
       <label for="distance_tolerance">Distance tolerance (arcsec) </label>
       <input type="text" class="form-control" id="distance_tolerance" name="distance_tolerance" value="{{distance_tolerance}}">
@@ -65,13 +65,16 @@ class="with-background"
                monospace;"
         rows="10" cols="80" name="stars_text">{{stars_text}}</textarea>
     </div>
+    </div>
   </div>
 
   <button type="submit" name="action" value="calc_solution">Find Attitude (no constraints)</button>
 
   <br></br>
   <br></br>
+  </div>
 
+  <div style="width: 50%; float: right;">
   <P><B>Optional Constraints:</B></P>
   <div class="row">
     <div class="col">
@@ -114,8 +117,11 @@ class="with-background"
     </div>
   </div>
   <button type="submit" name="action" value="calc_solution_constraints">Find Attitude with Constraints</button>
+  </div>
 
 </form>
+<br style="clear:both;"/>
+</div>
 
 <br></br>
 <br></br>


### PR DESCRIPTION
## Description

Add html form pieces to support find_attitude >= 3.5.0 Constraints.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Installed on kadi-test for functional testing.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] OSX
```
(2025.1-web) flame:kadi-apps jean$ pytest
============================================== test session starts ==============================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1, dash-2.18.2
collected 26 items                                                                                              

kadi_apps/tests/test_astromon.py ....                                                                     [ 15%]
kadi_apps/tests/test_auth.py .......                                                                      [ 42%]
kadi_apps/tests/test_ska_api.py ...............                                                           [100%]

=============================================== warnings summary ================================================
kadi-apps/kadi_apps/tests/test_ska_api.py::test_starcheck_att
kadi-apps/kadi_apps/tests/test_ska_api.py::test_starcheck_att
  /Users/jean/miniforge3/envs/2025.1-web/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================== 26 passed, 2 warnings in 11.42s ========================================
(2025.1-web) flame:kadi-apps jean$ git rev-parse HEAD
51d99e3ac35201c55c40e11bfd4866610301f147
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
The new form looks like this:

<img width="1259" alt="Screenshot 2025-01-10 at 11 21 12 AM" src="https://github.com/user-attachments/assets/bc6825a3-10a8-4448-abd6-4624d4f9dff8" />



And there's some new debug output that I found useful:
```
Date for Pitch/Roll: 2024:352:16:46:13.501
Sun Pitch: 149.9392937259457
Off-Nominal Roll: 7.276478482670257
```
```
Supplied find_attitude Inputs

slot   YAG      ZAG    MAG_ACA
---- -------- -------- -------
   3   669.65   144.72    7.25
   4  2454.88  -262.43    7.38
   5   978.08 -1594.53    8.31
   6 -1083.78   810.93     8.5
   7   -619.5    808.6    8.62 
 tolerance=2.5 
 constraints={}
find_attitude version: 3.5.1.dev0+g0b22b6b.d20241217
```

#### TA functional testing

All the tests below were OK.

- [x] During a maneuver in real time, the app reports no stars tracked during a maneuver.
- [x] Test with two stars during a normal observation where multiple solutions are found.
- [x] Test with three stars during a normal observation where multiple solutions are found.
- [x] Test various combinations of providing / not providing constraints.
- [x] Test gettings solutions in Safe Mode at 2023:046:00:34:15.230 with slots 1, 5, 6, 7.
   - No constraints and 3.0 arcsec dist tolerance finds no solution.
   - Sun pitch=90, pitch error=1.5, max_off_nom_roll = 2.0 matches 3 stars and gives solution.
   - Sun pitch=90, pitch error=1.5, max_off_nom_roll = 2.0, dist=4.0 arcsec matches 4 stars and gives solution.
