### PR TITLE
Update test to use MAG_ACA column that exists

### DIFF
--- a/kadi_apps/tests/test_ska_api.py
+++ b/kadi_apps/tests/test_ska_api.py
@@ -19,7 +19,7 @@ def test_agasc_star(test_server):
     response = requests.get(f"{api_url}/{path}?id={agasc_id}&{date=}")
     star_api = Table(response.json())[0]
     # for some reason, RA_PMCORR and DEC_PMCORR differ, so I take only a few columns anyway:
-    cols = ['AGASC_ID', 'RA', 'DEC', 'MAG']
+    cols = ['AGASC_ID', 'RA', 'DEC', 'MAG_ACA']
     assert list(star[cols].values()) == list(star_api[cols].values())
 
 
@@ -49,7 +49,7 @@ def test_agasc_stars(test_server):
     assert response.ok, 'test_agasc_stars API request failed'
     stars_api = Table(response.json())
     # for some reason, RA_PMCORR and DEC_PMCORR differ, so I take only a few columns anyway:
-    cols = ['AGASC_ID', 'RA', 'DEC', 'MAG']
+    cols = ['AGASC_ID', 'RA', 'DEC', 'MAG_ACA']
     assert np.all(stars_api.as_array().astype(stars.dtype)[cols] == stars.as_array()[cols])
 
 
@@ -66,7 +66,7 @@ def test_agasc_cone(test_server):
     assert response.ok, 'test_agasc_cone API request failed'
     assert len(stars) == len(stars_api)
     # for some reason, RA_PMCORR and DEC_PMCORR differ, so I take only a few columns anyway:
-    cols = ['AGASC_ID', 'RA', 'DEC', 'MAG']
+    cols = ['AGASC_ID', 'RA', 'DEC', 'MAG_ACA']
     assert np.all(stars_api.as_array().astype(stars.dtype)[cols] == stars.as_array()[cols])
 
 


### PR DESCRIPTION
## Description

Update test to use MAG_ACA column that exists

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes test failing looking for 'MAG':
```
FAILED kadi_apps/tests/test_ska_api.py::test_agasc_star - KeyError: 'MAG'
FAILED kadi_apps/tests/test_ska_api.py::test_agasc_stars - KeyError: 'MAG'
FAILED kadi_apps/tests/test_ska_api.py::test_agasc_cone - KeyError: 'MAG'
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-web) flame:kadi-apps jean$ git rev-parse HEAD
6cb445827d9cc18112122e30c846e660188bbb1f
(ska3-web) flame:kadi-apps jean$ pytest
============================================================================ test session starts =============================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: dash-2.9.2, timeout-2.2.0, anyio-4.3.0
collected 26 items                                                                                                                                                           

kadi_apps/tests/test_astromon.py ....                                                                                                                                  [ 15%]
kadi_apps/tests/test_auth.py .......                                                                                                                                   [ 42%]
kadi_apps/tests/test_ska_api.py ...............                                                                                                                        [100%]

============================================================================ 26 passed in 11.96s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
