### PR TITLE
Fix auth test

### DIFF
--- a/kadi_apps/tests/test_auth.py
+++ b/kadi_apps/tests/test_auth.py
@@ -111,7 +111,10 @@ def test_private(test_server):
     assert r.status_code == 401
     data = json.loads(r.text)
 
+    # the following test checks (or used to) that an unsigned token was not accepted at face value
+    # (i.e.: the checking algorithm did not check using the algorithm claimed by the token itself)
     claims = jwt.decode(token, options={"verify_signature": False}, algorithms="none")
-    unsigned_token = jwt.encode(claims, None, algorithm=None)
+    unsigned_token = jwt.encode(claims, "", algorithm=None)
     headers = {"Authorization": f"Bearer {unsigned_token}"}
+    r = requests.get(f'{test_server["url"]}/test', headers=headers)
     assert not r.ok


### PR DESCRIPTION
## Description

Fix the failing `kadi_apps/tests/test_auth.py::test_private`, which failed with
```
FAILED kadi_apps/tests/test_auth.py::test_private - TypeError: Expected a string value
```

This is caused by the key being `None`, but anyway the test would not have worked, since the request was never made.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
Requires skare3 >= 2025.1
<!-- If relevant describe any special setup for testing. -->

### Unit tests

Note that this test run includes the changes in PR #27 

<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc6) ~/SAO/git/kadi-apps mag $ pytest kadi_apps                                            
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1, dash-2.18.2
collected 26 items                                                                                                                                          

kadi_apps/tests/test_astromon.py ....                                                                                                                 [ 15%]
kadi_apps/tests/test_auth.py .......                                                                                                                  [ 42%]
kadi_apps/tests/test_ska_api.py ...............                                                                                                       [100%]

============================================================== 26 passed in 11.32s ==============================================================
(ska3-flight-2025.0rc6) ~/SAO/git/kadi-apps mag $ git rev-parse HEAD
779abff9f02ea634f0d494375f0f1ffeb5e0ba21
```

Independent check of unit tests by Jean
- [x] OSX with a 2025.1 environment plus the flask/web packages
```
Test failure on main
================================================================ short test summary info ================================================================
FAILED kadi_apps/tests/test_auth.py::test_private - TypeError: Expected a string value
======================================================= 1 failed, 25 passed, 2 warnings in 13.84s =======================================================
(2025.1-web) flame:kadi-apps jean$ git checkout fix-auth-test
branch 'fix-auth-test' set up to track 'origin/fix-auth-test'.
Switched to a new branch 'fix-auth-test'
(2025.1-web) flame:kadi-apps jean$ git rev-parse HEAD
779abff9f02ea634f0d494375f0f1ffeb5e0ba21
(2025.1-web) flame:kadi-apps jean$ pytest
================================================================== test session starts ==================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1, dash-2.18.2
collected 26 items                                                                                                                                      

kadi_apps/tests/test_astromon.py ....                                                                                                             [ 15%]
kadi_apps/tests/test_auth.py .......                                                                                                              [ 42%]
kadi_apps/tests/test_ska_api.py ...............                                                                                                   [100%]

=================================================================== warnings summary ====================================================================
kadi-apps/kadi_apps/tests/test_ska_api.py::test_starcheck_att
kadi-apps/kadi_apps/tests/test_ska_api.py::test_starcheck_att
  /Users/jean/miniforge3/envs/2025.1-web/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================ 26 passed, 2 warnings in 13.11s
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
