### PR TITLE
Add input field to find_attitude app to change MAUDE channel

### DIFF
--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -134,7 +134,8 @@ def index():
     # But override with any values from the form
     for key in DEFAULT_CONSTRAINTS:
         form_val = request.form.get(key)
-        context[key] = convert_to_int_float_str(form_val)
+        if form_val is not None:
+            context[key] = convert_to_int_float_str(form_val)
 
 
     if context.get('solutions'):

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -48,7 +48,6 @@ blueprint = Blueprint(
 
 
 def get_telem_from_maude(date=None, channel="FLIGHT"):
-
     msids = []
     for msid_root in ["aoacfct", "aoacfid", "aoacyan", "aoaczan", "aoacmag"]:
         msids.extend([f"{msid_root}{ii}" for ii in range(8)])
@@ -62,7 +61,7 @@ def get_telem_from_maude(date=None, channel="FLIGHT"):
         kwargs = {'start': start, 'stop': stop}
     else:
         kwargs = {}
-    dat = get_msids(msids, **kwargs)
+    dat = get_msids(msids, **kwargs, channel=channel)
     results = dat["data"]
     out = {}
     for result in results:
@@ -184,8 +183,9 @@ def find_solutions_and_get_context(action):
     stars_text = request.form.get('stars_text', '')
     context = {}
     att_est = None
+    maude_channel = request.form.get('maude_channel', 'FLIGHT')
+    context["maude_channel"] = maude_channel
     if stars_text.strip() == '' or action == 'gettelem':
-        maude_channel = request.form.get('maude_channel', 'FLIGHT')
         # Get date for solution, defaulting to NOW for any blank input
         date_solution = request.form.get('date_solution', '').strip() or None
         try:

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -245,7 +245,7 @@ def find_solutions_and_get_context(action):
         return context
 
     # Try to find solutions
-    tolerance = float(request.form.get('distance_tolerance', '2.5'))
+    tolerance = float(request.form.get('distance_tolerance', '3.0'))
 
     # Keep any constraints in the form for next submission
     for constraint in POSSIBLE_CONSTRAINTS:

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -18,6 +18,7 @@ from flask import Blueprint, request
 from kadi import __version__
 from maude import get_msids
 from Quaternion import Quat, normalize
+from ska_helpers.utils import convert_to_int_float_str
 
 from kadi_apps.rendering import render_template
 
@@ -130,13 +131,8 @@ def index():
     # Update some constraints to their default values if not set.
     for key, value in DEFAULT_CONSTRAINTS.items():
         form_val = request.form.get(key)
-        if form_val is not None and form_val.strip() == "":
-            if key == 'maude_channel':
-                value = form_val
-                context[key] = value
-            else:
-                value = float(form_val)
-                context[key] = value
+        if form_val is not None and form_val.strip() != "":
+            context[key] = convert_to_int_float_str(form_val)
         if key not in context:
             context[key] = value
 

--- a/kadi_apps/blueprints/find_attitude/find_attitude.py
+++ b/kadi_apps/blueprints/find_attitude/find_attitude.py
@@ -128,13 +128,14 @@ def index():
     context['generation_time'] = generation_time
     context['kadi_version'] = __version__
 
-    # Update some constraints to their default values if not set.
-    for key, value in DEFAULT_CONSTRAINTS.items():
+    # Update some constraints to their default values
+    context.update(DEFAULT_CONSTRAINTS)
+
+    # But override with any values from the form
+    for key in DEFAULT_CONSTRAINTS:
         form_val = request.form.get(key)
-        if form_val is not None and form_val.strip() != "":
-            context[key] = convert_to_int_float_str(form_val)
-        if key not in context:
-            context[key] = value
+        context[key] = convert_to_int_float_str(form_val)
+
 
     if context.get('solutions'):
         context['subtitle'] = ': Solution'

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -45,7 +45,10 @@ class="with-background"
     </div>
     <div class="col">
       <label for="maude_channel">MAUDE channel</label>
-      <input type="text" class="form-control" id="maude_channel" name="maude_channel" value="{{maude_channel}}">
+      <select class="form-control" id="maude_channel" name="maude_channel">
+      <option value="FLIGHT" {% if maude_channel == "FLIGHT" %}selected{% endif %}>FLIGHT</option>
+      <option value="ASVT" {% if maude_channel == "ASVT" %}selected{% endif %}>ASVT</option>
+      </select>
     </div>
   </div>
   </div>

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -38,10 +38,16 @@ class="with-background"
   <button type="submit" name="action" value="gettelem">Get Telem</button>
   <div class="row">
     <div class="col">
+      <div class="row">
     <div class="col">
       <label for="distance_tolerance">Distance tolerance (arcsec) </label>
       <input type="text" class="form-control" id="distance_tolerance" name="distance_tolerance" value="{{distance_tolerance}}">
     </div>
+    <div class="col">
+      <label for="maude_channel">MAUDE channel</label>
+      <input type="text" class="form-control" id="maude_channel" name="maude_channel" value="{{maude_channel}}">
+    </div>
+  </div>
   </div>
   &nbsp;
   <div class="row">


### PR DESCRIPTION
## Description

Add input field to change MAUDE channel


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
flame:kadi-apps jean$ pytest
============================================================= test session starts ==============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1, dash-2.18.2
collected 26 items                                                                                                                             

kadi_apps/tests/test_astromon.py ....                                                                                                    [ 15%]
kadi_apps/tests/test_auth.py .......                                                                                                     [ 42%]
kadi_apps/tests/test_ska_api.py ...............                                                                                          [100%]

=============================================================== warnings summary ===============================================================
kadi-apps/kadi_apps/tests/test_ska_api.py::test_starcheck_att
kadi-apps/kadi_apps/tests/test_ska_api.py::test_starcheck_att
  /Users/jean/miniforge3/envs/2025.1-web/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 26 passed, 2 warnings in 14.25s ========================================================
(2025.1-web) flame:kadi-apps jean$ git rev-parse HEAD
3d3585526a0f9be02cd0ded60377c9876acbadb6
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I set this to be live on kadi-test and confirmed telemetry that matches some from today's SIM:


<img width="644" alt="Screenshot 2025-03-12 at 4 57 18 PM" src="https://github.com/user-attachments/assets/58e78ffc-c55c-45c3-9d1e-93c6d22cd476" />
