### PR TITLE
Add javascript for ASVT/SIM time warning

### DIFF
--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -45,10 +45,15 @@ class="with-background"
     </div>
     <div class="col">
       <label for="maude_channel">MAUDE channel</label>
-      <select class="form-control" id="maude_channel" name="maude_channel">
+      <select class="form-control" id="maude_channel" name="maude_channel" onchange="toggleAsvtWarning(this.value)">
       <option value="FLIGHT" {% if maude_channel == "FLIGHT" %}selected{% endif %}>FLIGHT</option>
       <option value="ASVT" {% if maude_channel == "ASVT" %}selected{% endif %}>ASVT</option>
       </select>
+    </div>
+  </div>
+  <div class="row" id="asvt_warning" style="display: {% if maude_channel == 'ASVT' %}block{% else %}none{% endif %};">
+    <div class="col">
+      <p style="color: darkred; font-weight: bold;">When using ASVT maude channel for a SIM, after fetching telemetry remember to update solution date to simulation time for accurate pitch constraint handling</p>
     </div>
   </div>
   </div>
@@ -216,5 +221,11 @@ slot yag zag mag
 7     573.25   -2411.70      7.1
 </pre>
 {% endif %}
+
+<script>
+function toggleAsvtWarning(channel) {
+  document.getElementById('asvt_warning').style.display = channel === 'ASVT' ? 'block' : 'none';
+}
+</script>
 
 {% endblock %}

--- a/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
+++ b/kadi_apps/blueprints/find_attitude/templates/find_attitude/index.html
@@ -53,7 +53,7 @@ class="with-background"
   </div>
   <div class="row" id="asvt_warning" style="display: {% if maude_channel == 'ASVT' %}block{% else %}none{% endif %};">
     <div class="col">
-      <p style="color: darkred; font-weight: bold;">When using ASVT maude channel for a SIM, after fetching telemetry remember to update solution date to simulation time for accurate pitch constraint handling</p>
+      <p style="color: darkred; font-weight: bold;">When using ASVT maude channel for a SIM, after fetching telemetry remember to update solution date to simulation time for accurate pitch constraint handling.</p>
     </div>
   </div>
   </div>


### PR DESCRIPTION
## Description

Adds this text "When using ASVT maude channel for a SIM, after fetching telemetry remember to update solution date to simulation time for accurate pitch constraint handling." when ASVT channel is selected in find_attitude app.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->

- [x] Mac

It looks like the astromon tests don't all pass, but that isn't related to this text change
```
(ska3-latest) flame:kadi-apps jean$ pytest
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0, dash-4.4.1
collected 26 items                                                                                                                                            

kadi_apps/tests/test_astromon.py ..FF                                                                                                                   [ 15%]
kadi_apps/tests/test_auth.py .......                                                                                                                    [ 42%]
kadi_apps/tests/test_ska_api.py ...............                                                                                                         [100%]

========================================================================== FAILURES ===========================================================================
_________________________________________________________________________ test_obsid

```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Quick local functional testing:

<img width="583" height="282" alt="Screenshot 2026-08-03 at 3 24 21 PM" src="https://github.com/user-attachments/assets/8c7640a9-7e59-4d3a-a9d2-bd02a15c98c0" />
